### PR TITLE
Fix module conflict issue

### DIFF
--- a/Core/src/Network/Messages/FusionMessage.cs
+++ b/Core/src/Network/Messages/FusionMessage.cs
@@ -92,11 +92,12 @@ namespace LabFusion.Network
             // Make sure the tag is valid, otherwise we dont return a message
             if (tag.HasValue) {
                 var value = tag.Value;
+                var tagBytes = BitConverter.GetBytes(value);
 
                 var message = Internal_Create(size);
                 message._buffer[0] = NativeMessageTag.Module;
-                message._buffer[1] = (byte)(value >> 8);
-                message._buffer[2] = (byte)value;
+                message._buffer[1] = tagBytes[0];
+                message._buffer[2] = tagBytes[1];
 
                 for (var i = 0; i < length; i++) {
                     message._buffer[i + 3] = buffer[i];

--- a/Core/src/Network/Messages/FusionMessage.cs
+++ b/Core/src/Network/Messages/FusionMessage.cs
@@ -92,7 +92,7 @@ namespace LabFusion.Network
             // Make sure the tag is valid, otherwise we dont return a message
             if (tag.HasValue) {
                 var value = tag.Value;
-                var tagBytes = BitConverter.GetBytes(value);
+                var tagBytes = BitConverter.GetBytes((ushort)value);
 
                 var message = Internal_Create(size);
                 message._buffer[0] = NativeMessageTag.Module;


### PR DESCRIPTION
There was a small error in the way a modules id was sent over the network, which made tag ids that were above 0 return 256. This caused only the module with id 0 to ever function properly, the rest would be out of range of the Handlers list. This PR fixes this issue by removing the bit manipulation and just using BitConverter instead.