### PR TITLE
Implement QOL Public Lobby Features

### DIFF
--- a/Core/FusionHelper/Network/MessageTypes.cs
+++ b/Core/FusionHelper/Network/MessageTypes.cs
@@ -23,5 +23,6 @@
         UpdateConnectPresence = 18,
         DecompressVoice = 19,
         SetLobbyMetadata = 20,
+        FriendsList = 21,
     }
 }

--- a/Core/FusionHelper/Network/NetworkHandler.cs
+++ b/Core/FusionHelper/Network/NetworkHandler.cs
@@ -330,6 +330,23 @@ namespace FusionHelper.Network
                         SteamHandler.SetMetadata(dataReader.GetString(), dataReader.GetString());
                         break;
                     }
+                case (ulong)MessageTypes.FriendsList:
+                    {
+                        int friendCount = SteamFriends.GetFriendCount(EFriendFlags.k_EFriendFlagImmediate);
+                        List<ulong> friendIds = new List<ulong>();
+                        List<string> friendNames = new List<string>();
+                        for (int i = 0; i < friendCount; ++i)
+                        {
+                            CSteamID friendSteamID = SteamFriends.GetFriendByIndex(i, EFriendFlags.k_EFriendFlagImmediate);
+                            friendIds.Add(friendSteamID.m_SteamID);
+                            friendNames.Add(SteamFriends.GetFriendPersonaName(friendSteamID));
+                        }
+                        NetDataWriter writer = NewWriter(MessageTypes.FriendsList);
+                        writer.PutArray(friendIds.ToArray());
+                        writer.PutArray(friendNames.ToArray());
+                        SendToClient(writer);
+                        break;
+                    }
             }
 
             dataReader.Recycle();

--- a/Core/src/BoneMenu/LobbyCreator.cs
+++ b/Core/src/BoneMenu/LobbyCreator.cs
@@ -114,6 +114,9 @@ namespace LabFusion.BoneMenu
             // Show their version
             generalInfoPanel.CreateFunctionElement($"Version: {info.LobbyVersion}", versionColor, null);
 
+            // Show their platform
+            generalInfoPanel.CreateFunctionElement($"Platform: {(info.IsQuestLobby ? "Quest" : "PC")}", Color.white, null);
+
             // Show their active level
             Color levelColor = info.ClientHasLevel ? Color.white : Color.red;
 

--- a/Core/src/Network/Helpers/LobbyMetadataHelper.cs
+++ b/Core/src/Network/Helpers/LobbyMetadataHelper.cs
@@ -26,6 +26,7 @@ namespace LabFusion.Network
         public bool HasServerOpen;
         public int PlayerCount;
         public PlayerList PlayerList;
+        public bool IsQuestLobby;
 
         // Lobby settings
         public bool NametagsEnabled;
@@ -61,6 +62,7 @@ namespace LabFusion.Network
                 HasServerOpen = NetworkInfo.IsServer,
                 PlayerCount = PlayerIdManager.PlayerCount,
                 PlayerList = playerList,
+                IsQuestLobby = PlayerIdManager.LocalId.GetMetadata(MetadataHelper.PlatformKey) == "QUEST",
 
                 // Lobby settings
                 NametagsEnabled = FusionPreferences.LocalServerSettings.NametagsEnabled.GetValue(),
@@ -90,6 +92,7 @@ namespace LabFusion.Network
             lobby.SetMetadata(LobbyConstants.HasServerOpenKey, HasServerOpen.ToString());
             lobby.SetMetadata(nameof(PlayerCount), PlayerCount.ToString());
             lobby.SetMetadata(nameof(PlayerList), PlayerList.WriteDocument().ToString());
+            lobby.SetMetadata(nameof(IsQuestLobby), IsQuestLobby.ToString());
 
             // Lobby settings
             lobby.SetMetadata(nameof(NametagsEnabled), NametagsEnabled.ToString());
@@ -162,6 +165,10 @@ namespace LabFusion.Network
                 info.LobbyVersion = version;
             else
                 info.LobbyVersion = new Version(0, 0, 0);
+
+            // Get lobby platform
+            if (bool.TryParse(lobby.GetMetadata(nameof(IsQuestLobby)), out bool isQuestLobby))
+                info.IsQuestLobby = isQuestLobby;
 
             // Get longs
             if (ulong.TryParse(lobby.GetMetadata(nameof(LobbyId)), out var lobbyId))

--- a/Core/src/Network/Steam/SteamNetworkLayer.cs
+++ b/Core/src/Network/Steam/SteamNetworkLayer.cs
@@ -468,6 +468,15 @@ namespace LabFusion.Network
 
             // Public lobbies list
             _publicLobbiesCategory = matchmaking.CreateCategory("Public Lobbies", Color.white);
+
+            /// Lobby Filtering
+            var filteringCategory = _publicLobbiesCategory.CreateSubPanel("Filters", Color.white);
+            BoneMenuCreator.CreateBoolPreference(filteringCategory, "Show Full Lobbies", FusionPreferences.ClientSettings.ShowFullLobbies);
+            BoneMenuCreator.CreateBoolPreference(filteringCategory, "Show Quest Lobbies", FusionPreferences.ClientSettings.ShowQuestLobbies);
+            BoneMenuCreator.CreateBoolPreference(filteringCategory, "Show PC Lobbies", FusionPreferences.ClientSettings.ShowPcLobbies);
+            BoneMenuCreator.CreateBytePreference(filteringCategory, "Maximum Max Players", 1, 2, 255, FusionPreferences.ClientSettings.MaximumMaxPlayers);
+            BoneMenuCreator.CreateBytePreference(filteringCategory, "Minimum Max Players", 1, 2, 255, FusionPreferences.ClientSettings.MinimumMaxPlayers);
+
             _publicLobbiesCategory.CreateFunctionElement("Refresh", Color.white, Menu_RefreshPublicLobbies);
             _publicLobbiesCategory.CreateFunctionElement("Select Refresh to load servers!", Color.yellow, null);
 
@@ -556,6 +565,15 @@ namespace LabFusion.Network
 
             // Clear existing lobbies
             _publicLobbiesCategory.Elements.Clear();
+
+            /// Lobby Filtering
+            var filteringCategory = _publicLobbiesCategory.CreateSubPanel("Filters", Color.white);
+            BoneMenuCreator.CreateBoolPreference(filteringCategory, "Show Full Lobbies", FusionPreferences.ClientSettings.ShowFullLobbies);
+            BoneMenuCreator.CreateBoolPreference(filteringCategory, "Show Quest Lobbies", FusionPreferences.ClientSettings.ShowQuestLobbies);
+            BoneMenuCreator.CreateBoolPreference(filteringCategory, "Show PC Lobbies", FusionPreferences.ClientSettings.ShowPcLobbies);
+            BoneMenuCreator.CreateBytePreference(filteringCategory, "Maximum Max Players", 1, 2, 255, FusionPreferences.ClientSettings.MaximumMaxPlayers);
+            BoneMenuCreator.CreateBytePreference(filteringCategory, "Minimum Max Players", 1, 2, 255, FusionPreferences.ClientSettings.MinimumMaxPlayers);
+
             _publicLobbiesCategory.CreateFunctionElement("Refresh", Color.white, Menu_RefreshPublicLobbies);
             _publicLobbiesCategory.CreateEnumElement("Sort By", Color.white, _publicLobbySortMode, (v) =>
             {
@@ -570,6 +588,19 @@ namespace LabFusion.Network
         {
             // Make sure the lobby is actually open
             if (!info.HasServerOpen)
+                return false;
+
+            // Lobby Filtering Options
+            if (!FusionPreferences.ClientSettings.ShowFullLobbies.GetValue())
+                if (info.PlayerCount == info.MaxPlayers)
+                    return false;
+            if (!FusionPreferences.ClientSettings.ShowQuestLobbies.GetValue() && info.IsQuestLobby)
+                return false;
+            if (!FusionPreferences.ClientSettings.ShowPcLobbies.GetValue() && !info.IsQuestLobby)
+                return false;
+            if (info.MaxPlayers < FusionPreferences.ClientSettings.MinimumMaxPlayers.GetValue())
+                return false;
+            if (info.MaxPlayers > FusionPreferences.ClientSettings.MaximumMaxPlayers.GetValue())
                 return false;
 
             // Decide if this server is too private

--- a/Core/src/Preferences/FusionPreferences.cs
+++ b/Core/src/Preferences/FusionPreferences.cs
@@ -116,6 +116,13 @@ namespace LabFusion.Preferences
             // Gamemode settings
             public static FusionPref<bool> GamemodeMusic { get; internal set; }
             public static FusionPref<bool> GamemodeLateJoining { get; internal set; }
+
+            // Lobby Filtering
+            public static FusionPref<bool> ShowFullLobbies { get; internal set; }
+            public static FusionPref<byte> MinimumMaxPlayers { get; internal set; }
+            public static FusionPref<byte> MaximumMaxPlayers { get; internal set; }
+            public static FusionPref<bool> ShowQuestLobbies { get; internal set; }
+            public static FusionPref<bool> ShowPcLobbies { get; internal set; }
         }
 
         internal static ServerSettings LocalServerSettings;
@@ -199,6 +206,13 @@ namespace LabFusion.Preferences
             // Gamemodes
             ClientSettings.GamemodeMusic = new FusionPref<bool>(prefCategory, "Gamemode Music", true, PrefUpdateMode.IGNORE);
             ClientSettings.GamemodeLateJoining = new FusionPref<bool>(prefCategory, "Gamemode Late Joining", true, PrefUpdateMode.IGNORE);
+
+            // Lobby Filtering
+            ClientSettings.ShowFullLobbies = new FusionPref<bool>(prefCategory, "Show Full Lobbies", false, PrefUpdateMode.IGNORE);
+            ClientSettings.MinimumMaxPlayers = new FusionPref<byte>(prefCategory, "Minimum Max Players", 2, PrefUpdateMode.IGNORE);
+            ClientSettings.MaximumMaxPlayers = new FusionPref<byte>(prefCategory, "Maximum Max Players", 10, PrefUpdateMode.IGNORE);
+            ClientSettings.ShowQuestLobbies = new FusionPref<bool>(prefCategory, "Show Quest Lobbies", true, PrefUpdateMode.IGNORE);
+            ClientSettings.ShowPcLobbies = new FusionPref<bool>(prefCategory, "Show PC Lobbies", true, PrefUpdateMode.IGNORE);
 
             // Save category
             prefCategory.SaveToFile(false);


### PR DESCRIPTION
This PR includes:
-Steam Friends for Quest, which refreshes the friends list every lobby update -Lobby Filtering which has:
+Hiding Full Lobbies
+Hiding Min/Max Player Counts
+Hiding Quest/PC Lobbies
-Public Lobbies now display which platform they are on (Quest/PC)