### PR TITLE
Remove custom PlayerCount tracking inside of Team.cs

### DIFF
--- a/Core/src/SDK/Gamemodes/Team.cs
+++ b/Core/src/SDK/Gamemodes/Team.cs
@@ -62,7 +62,8 @@ namespace LabFusion.SDK.Gamemodes
             }
 
             Players.Add(playerId);
-
+            PlayerCount++;
+            
             ConstructLogoInstance(playerId);
         }
 

--- a/Core/src/SDK/Gamemodes/Team.cs
+++ b/Core/src/SDK/Gamemodes/Team.cs
@@ -46,7 +46,7 @@ namespace LabFusion.SDK.Gamemodes
 
         public List<PlayerId> Players { get; }
 
-        public int PlayerCount { get; private set; }
+        public int PlayerCount => Players.Count;
         public int MaxPlayers { get; }
 
         public AudioClip WinMusic { get; private set; }
@@ -62,7 +62,6 @@ namespace LabFusion.SDK.Gamemodes
             }
 
             Players.Add(playerId);
-            PlayerCount++;
             
             ConstructLogoInstance(playerId);
         }
@@ -75,7 +74,6 @@ namespace LabFusion.SDK.Gamemodes
             }
 
             Players.Remove(playerId);
-            PlayerCount--;
 
             TeamLogoInstance playerLogo = LogoInstances.Find((logo) => logo.playerId == playerId);
             LogoInstances.Remove(playerLogo);


### PR DESCRIPTION
This issue came to my attention while I was writing a Gamemode for BONELAB Fusion. This custom tracking of the Player list's Length tracking is prone to bugs and unnecessary. 