### PR TITLE
Improved temporary mod behavior

### DIFF
--- a/LabFusion/src/Downloading/ModDownloadManager.cs
+++ b/LabFusion/src/Downloading/ModDownloadManager.cs
@@ -84,6 +84,36 @@ public static class ModDownloadManager
         return string.Empty;
     }
 
+    public static void ScheduleModLoad(ModIOFile modFile, string jsonPath, DownloadCallback downloadCallback = null)
+    {
+        StringModTargetListingDictionary targets = new();
+        var modIoModTarget = new ModIOModTarget()
+        {
+            GameId = ModIOSettings.GameID,
+            ModId = modFile.ModID,
+            ModfileId = modFile.FileID.Value,
+        };
+        targets.Add(ModIOManager.GetActivePlatform(), modIoModTarget);
+
+        ModListing listing = new()
+        {
+            Author = null,
+            Barcode = null,
+            Description = null,
+            Repository = null,
+            Targets = targets,
+        };
+
+        var shipment = new ModForklift.PalletShipment()
+        {
+            palletPath = jsonPath,
+            modListing = listing,
+            callback = downloadCallback,
+        };
+
+        ModForklift.SchedulePalletLoad(shipment);
+    }
+
     public static void LoadPalletFromZip(string path, ModIOFile modFile, bool temporary, Action scheduledCallback = null, DownloadCallback downloadCallback = null)
     {
         MelonCoroutines.Start(CoLoadPalletFromZip(path, modFile, temporary, scheduledCallback, downloadCallback));
@@ -189,32 +219,7 @@ public static class ModDownloadManager
         FusionLogger.Log($"Scheduling pallet for load at path {jsonPath}");
 #endif
 
-        StringModTargetListingDictionary targets = new();
-        var modIoModTarget = new ModIOModTarget()
-        {
-            GameId = ModIOSettings.GameID,
-            ModId = modFile.ModID,
-            ModfileId = modFile.FileID.Value,
-        };
-        targets.Add(ModIOManager.GetActivePlatform(), modIoModTarget);
-
-        ModListing listing = new()
-        {
-            Author = null,
-            Barcode = null,
-            Description = null,
-            Repository = null,
-            Targets = targets,
-        };
-
-        var shipment = new ModForklift.PalletShipment()
-        {
-            palletPath = jsonPath,
-            modListing = listing,
-            callback = downloadCallback,
-        };
-
-        ModForklift.SchedulePalletLoad(shipment);
+        ScheduleModLoad(modFile, jsonPath, downloadCallback);
 
         // Run scheduled callback
         scheduledCallback?.Invoke();

--- a/LabFusion/src/Downloading/ModDownloadManager.cs
+++ b/LabFusion/src/Downloading/ModDownloadManager.cs
@@ -2,23 +2,22 @@
 
 using LabFusion.Downloading.ModIO;
 using LabFusion.Utilities;
+using LabFusion.Preferences.Client;
 
 using MelonLoader;
 
 using System.Collections;
 using System.IO.Compression;
 
-using UnityEngine;
-
 namespace LabFusion.Downloading;
 
 public static class ModDownloadManager
 {
-    public static string ModsPath => Application.persistentDataPath + "/Mods";
+    public static string ModsPath => ClientSettings.Downloading.ModsPath.Value;
 
-    public static string ModsTempPath => Application.persistentDataPath + "/ModsTemp";
+    public static string ModsTempPath => ClientSettings.Downloading.RootDownloadPath.Value + "/ModsTemp";
 
-    public static string StagingPath => Application.persistentDataPath + "/FusionStaging";
+    public static string StagingPath => ClientSettings.Downloading.RootDownloadPath.Value + "/FusionStaging";
 
     public static string DownloadPath => StagingPath + "/Downloads";
 

--- a/LabFusion/src/Menu/Pages/MenuSettings.cs
+++ b/LabFusion/src/Menu/Pages/MenuSettings.cs
@@ -201,6 +201,9 @@ public static class MenuSettings
         generalGroup.AddElement<BoolElement>("Download Mature Content")
             .AsPref(ClientSettings.Downloading.DownloadMatureContent)
             .WithColor(Color.red);
+
+        generalGroup.AddElement<BoolElement>("Clear Download Cache Next Launch")
+            .AsPref(ClientSettings.Downloading.ClearDownloadCache);
     }
 
     private static void PopulateSafetySettings(PageElement page)

--- a/LabFusion/src/Mod.cs
+++ b/LabFusion/src/Mod.cs
@@ -35,6 +35,7 @@ using MelonLoader;
 using Il2CppSLZ.Bonelab;
 using Il2CppSLZ.Marrow.Warehouse;
 using Il2CppSLZ.Marrow;
+using LabFusion.Preferences.Client;
 
 namespace LabFusion;
 
@@ -137,6 +138,13 @@ public class FusionMod : MelonMod
 
         // Create prefs
         FusionPreferences.OnInitializePreferences();
+
+        if (ClientSettings.Downloading.ClearDownloadCache.Value)
+        {
+            ClientSettings.Downloading.ClearDownloadCache.Value = false;
+
+            ModDownloadManager.DeleteTemporaryDirectories();
+        }
 
         FusionPermissions.OnInitializeMelon();
 

--- a/LabFusion/src/Mod.cs
+++ b/LabFusion/src/Mod.cs
@@ -81,9 +81,6 @@ public class FusionMod : MelonMod
         Instance = this;
         FusionAssembly = MelonAssembly.Assembly;
 
-        // Delete temporary downloads from the last session
-        ModDownloadManager.DeleteTemporaryDirectories();
-
         // Prepare the data path for writing files
         PersistentData.OnPathInitialize();
 

--- a/LabFusion/src/Preferences/Client/DownloadingSettings.cs
+++ b/LabFusion/src/Preferences/Client/DownloadingSettings.cs
@@ -24,6 +24,8 @@ public class DownloadingSettings
     public FusionPref<string> ModsPath { get; private set; }
     public FusionPref<string> RootDownloadPath { get; private set; }
 
+    public FusionPref<bool> ClearDownloadCache { get; private set; }
+
     public void CreatePrefs(MelonPreferences_Category category)
     {
         DownloadSpawnables = new FusionPref<bool>(category, "Download Spawnables", true, PrefUpdateMode.IGNORE);
@@ -41,5 +43,7 @@ public class DownloadingSettings
 
         ModsPath = new FusionPref<string>(category, "Mods Path", Application.persistentDataPath + "/Mods", PrefUpdateMode.IGNORE);
         RootDownloadPath = new FusionPref<string>(category, "Root Download Path", Application.persistentDataPath, PrefUpdateMode.IGNORE);
+
+        ClearDownloadCache = new FusionPref<bool>(category, "Clear Download Cache", false, PrefUpdateMode.IGNORE);
     }
 }

--- a/LabFusion/src/Preferences/Client/DownloadingSettings.cs
+++ b/LabFusion/src/Preferences/Client/DownloadingSettings.cs
@@ -1,4 +1,5 @@
 ﻿using MelonLoader;
+using UnityEngine;
 
 namespace LabFusion.Preferences.Client;
 
@@ -20,6 +21,9 @@ public class DownloadingSettings
 
     public FusionPref<bool> DownloadMatureContent { get; private set; }
 
+    public FusionPref<string> ModsPath { get; private set; }
+    public FusionPref<string> RootDownloadPath { get; private set; }
+
     public void CreatePrefs(MelonPreferences_Category category)
     {
         DownloadSpawnables = new FusionPref<bool>(category, "Download Spawnables", true, PrefUpdateMode.IGNORE);
@@ -34,5 +38,8 @@ public class DownloadingSettings
         MaxLevelSize = new FusionPref<int>(category, "Max Level Size", DefaultMaxLevelSize, PrefUpdateMode.IGNORE);
 
         DownloadMatureContent = new FusionPref<bool>(category, "Download Mature Content", false, PrefUpdateMode.IGNORE);
+
+        ModsPath = new FusionPref<string>(category, "Mods Path", Application.persistentDataPath + "/Mods", PrefUpdateMode.IGNORE);
+        RootDownloadPath = new FusionPref<string>(category, "Root Download Path", Application.persistentDataPath, PrefUpdateMode.IGNORE);
     }
 }

--- a/LabFusion/src/RPC/NetworkModRequester.cs
+++ b/LabFusion/src/RPC/NetworkModRequester.cs
@@ -110,6 +110,42 @@ public static class NetworkModRequester
                 return;
             }
 
+            // Guess mod path and check if it's already downloaded
+            string guessedPalletName;
+            var firstDot = installInfo.Barcode.IndexOf('.');
+
+            if (firstDot < 0 || firstDot >= installInfo.Barcode.Length - 1)
+            {
+                guessedPalletName = installInfo.Barcode;
+            }
+            else
+            {
+                var secondDot = installInfo.Barcode.IndexOf('.', firstDot + 1);
+
+                if (secondDot < 0)
+                {
+                    guessedPalletName = installInfo.Barcode;
+                }
+                else
+                {
+                    guessedPalletName = installInfo.Barcode[..secondDot];
+                }
+            }
+
+            var cachedModPath = ModDownloadManager.ModsTempPath + "/" + guessedPalletName;
+
+            if (Directory.Exists(cachedModPath))
+            {
+                var palletPath = ModDownloadManager.FindPalletJson(cachedModPath);
+
+                if (!string.IsNullOrEmpty(palletPath))
+                {
+                    ModDownloadManager.ScheduleModLoad(info.ModFile, palletPath, installInfo.FinishDownloadCallback);
+
+                    return;
+                }
+            }
+
             installInfo.BeginDownloadCallback?.Invoke(info);
 
             bool temporary = !ClientSettings.Downloading.KeepDownloadedMods.Value;

--- a/LabFusion/src/Scene/FusionSceneManager.cs
+++ b/LabFusion/src/Scene/FusionSceneManager.cs
@@ -8,6 +8,7 @@ using LabFusion.Marrow.Patching;
 
 using Il2CppSLZ.Marrow.SceneStreaming;
 using Il2CppSLZ.Marrow.Warehouse;
+using LabFusion.Downloading;
 
 namespace LabFusion.Scene;
 
@@ -57,6 +58,23 @@ public static partial class FusionSceneManager
             // Update loading state
             if (!_wasLoading)
             {
+                if (!NetworkInfo.HasServer)
+                {
+                    if (!ClientSettings.Downloading.KeepDownloadedMods.Value)
+                    {
+                        var warehouse = AssetWarehouse.Instance;
+                        var manifests = warehouse.GetPalletManifests();
+                        var modsTempPath = Path.GetFullPath(ModDownloadManager.ModsTempPath);
+
+                        foreach (var manifest in manifests)
+                        {
+                            if (!Path.GetFullPath(manifest.PalletPath).StartsWith(modsTempPath)) continue;
+
+                            warehouse.UnloadPallet(manifest.PalletBarcode);
+                        }
+                    }
+                }
+
                 LoadSender.SendLoadingState(true);
                 LocalPlayer.Metadata.LevelBarcode.SetValue(Barcode);
 


### PR DESCRIPTION
This PR improves the temporary mod behavior in 2 ways:

1. Temporary mods are now cached so they don't need to be downloaded again.
2. They get automatically unloaded when changing into a new level after disconnecting.

Furthermore it also adds a setting to clear the temporary mod cache the next time the game launches, and some advanced settings have been added to change the paths of mod directories.