### PR TITLE
Move NetworkLayers registration into NetworkLayerModule

### DIFF
--- a/LabFusion/src/Mod.cs
+++ b/LabFusion/src/Mod.cs
@@ -107,7 +107,6 @@ public class FusionMod : MelonMod
         // Register our base handlers
         NativeMessageHandler.RegisterHandlersFromAssembly(FusionAssembly);
         GrabGroupHandler.RegisterHandlersFromAssembly(FusionAssembly);
-        NetworkLayer.RegisterLayersFromAssembly(FusionAssembly);
         GamemodeRegistration.LoadGamemodes(FusionAssembly);
         PointItemManager.LoadItems(FusionAssembly);
         AchievementManager.LoadAchievements(FusionAssembly);

--- a/LabFusion/src/Network/Layers/NetworkLayerModule.cs
+++ b/LabFusion/src/Network/Layers/NetworkLayerModule.cs
@@ -1,0 +1,17 @@
+using LabFusion.SDK.Modules;
+
+namespace LabFusion.Network;
+
+public class NetworkLayerModule : Module
+{
+    public override string Name => "Network Layers";
+    public override string Author => FusionMod.ModAuthor;
+    public override Version Version => FusionMod.Version;
+
+    public override ConsoleColor Color => ConsoleColor.Green;
+
+    protected override void OnModuleRegistered()
+    {
+        NetworkLayer.RegisterLayersFromAssembly(FusionMod.FusionAssembly);
+    }
+}


### PR DESCRIPTION
Moves NetworkLayer registration from Mod.cs into a dedicated NetworkLayerModule

Addresses: "Move NetworkLayers into modules" (Cleanup/QoL)