### PR TITLE
docs: add Fusion codebase, networking, and economy guides

### DIFF
--- a/docs/CODEBASE_MAP.md
+++ b/docs/CODEBASE_MAP.md
@@ -1,0 +1,188 @@
+# BONELAB Fusion codebase map
+
+Source inspected: `Lakatrazz/BONELAB-Fusion` at `4b0505be680b3232f3b2db862a3dcd21bba43de7`.
+
+This is a focused developer map, not a complete API reference. It answers the questions from issue #107: where the main pieces live, how the runtime enters and updates them, how networking is layered, and where a gameplay/economy feature would plug in.
+
+## Top-level projects
+
+- `LabFusion/` — main Fusion mod. This contains the MelonLoader entrypoint, networking stack, player/entity replication, gamemode SDK, menus, point shop, voice, scene synchronization and most common multiplayer behavior.
+- `BonelabSupport/` — BONELAB-specific support module. It contains game-specific patches, messages and extenders for BONELAB controllers, arena/campaign behavior, props, player vitals and other BONELAB-only integration points.
+- `LabFusionUpdater/` — updater/plugin project used to keep Fusion releases current.
+- `Staging/` — release/staging material rather than the main runtime implementation.
+- `LabFusion.sln` — solution entrypoint for the C# projects.
+
+Inside `LabFusion/`, the most useful source roots for feature work are:
+
+- `src/Network/` — transport abstraction, lobby/matchmaking interfaces, connection lifecycle, serialization and message routing.
+- `src/Entities/` — networked entities, players, props, ownership/registration and per-frame entity updates.
+- `src/Player/` — local/network player behavior and player IDs.
+- `src/Scene/` — scene/level lifecycle and network scene synchronization.
+- `src/SDK/Gamemodes/` — base gamemode API, built-in gamemodes, teams and gamemode metadata.
+- `src/SDK/Points/` — persistent local point/"bit" balance, purchasable point items and point-shop state.
+- `src/SDK/Messages/` and `src/Network/Messages/` — module/native message contracts and handlers.
+- `src/Senders/` — higher-level helpers that construct and relay common messages.
+- `src/RPC/` — RPC registration and network asset spawning/request helpers.
+- `src/Menu/` and `src/UI/` — Fusion menu data/pages, matchmaking UI and popup UI.
+- `src/Support/` — support-module loading/coordination.
+- `src/Utilities/Fusion/MultiplayerHooking.cs` — common multiplayer lifecycle hooks used by systems such as gamemodes.
+
+## Runtime entrypoint and lifecycle
+
+The main entrypoint is `LabFusion/src/Mod.cs`, class `FusionMod : MelonMod`.
+
+### Early initialization
+
+`FusionMod.OnEarlyInitializeMelon()` performs the earliest state setup:
+
+1. stores the mod/assembly references;
+2. deletes temporary mod-download directories;
+3. initializes the persistent-data path;
+4. loads the Steam API;
+5. initializes player-data control;
+6. hooks point-item events;
+7. initializes the RPC manager.
+
+### Main initialization
+
+`FusionMod.OnInitializeMelon()` wires the systems that the rest of the runtime depends on. In rough order it:
+
+1. loads Fusion files and safety lists;
+2. initializes local-player and voice state;
+3. loads base/support modules;
+4. discovers message handlers, grab handlers, network layers, gamemodes, point items, achievements and RPCs by scanning the Fusion assembly;
+5. initializes network-entity and network-player managers;
+6. initializes popups and gamemode managers;
+7. creates preferences/permissions/lobby/menu state;
+8. initializes scene loading and `NetworkSceneManager`;
+9. initializes `NetworkLayerManager`.
+
+The important architectural pattern is that many feature types are **registered from the assembly**, rather than hard-coded into one central switch. For a new gameplay system, look for the registration base class/attribute first before adding global initialization code.
+
+## What happens every frame
+
+`FusionMod.OnUpdate()` is the clearest high-level execution trace:
+
+1. network byte counters reset;
+2. queued mod downloads update;
+3. time references update;
+4. scene-load state advances;
+5. popup UI updates;
+6. `NetworkTickManager.OnUpdate()` decides whether this frame is a network tick;
+7. network-player and network-entity managers update;
+8. local Fusion player state updates;
+9. voice chat updates;
+10. the active network transport's `OnUpdateLayer()` runs;
+11. delayed disconnects update through `NetworkConnectionManager`;
+12. shared multiplayer update hooks fire;
+13. the active gamemode updates;
+14. delayed events run at the end of the frame.
+
+`FusionMod.OnFixedUpdate()` runs physics-oriented work:
+
+- local player fixed update;
+- player-data controller fixed update;
+- network player/entity fixed updates;
+- multiplayer fixed-update hooks;
+- gamemode fixed update.
+
+`FusionMod.OnLateUpdate()` runs player/entity late updates, flushes leftover network-layer work, invokes late-update hooks, then updates the gamemode late phase.
+
+### Network tick rate
+
+`LabFusion/src/Network/NetworkTickManager.cs` defines a `20f` tick rate (`0.05s` between ticks). It exposes `IsTickThisFrame`, which systems can use to avoid sending state every render frame, plus an interpolation decay value for smoothing between updates.
+
+## Networking architecture
+
+Fusion separates gameplay messages from the concrete transport.
+
+### Transport abstraction
+
+`LabFusion/src/Network/Layers/NetworkLayer.cs` is the transport contract. A layer supplies:
+
+- platform identity;
+- host/client state;
+- lobby and matchmaker implementations;
+- voice manager;
+- login/logout;
+- start/disconnect operations;
+- send-to-server, server-to-client and broadcast operations;
+- per-frame/late-frame transport updates.
+
+`NetworkLayerManager` owns the currently active layer, handles layer login/logout events and initializes/deinitializes the selected transport. `NetworkLayerDeterminer` selects the target layer; current concrete implementations live under `src/Network/Layers/Steam/` and `src/Network/Layers/Proxy/`.
+
+That means game logic should normally depend on `NetworkInfo`, `MessageRelay` and message handlers, not directly on a Steam socket class.
+
+### Sending a message
+
+The common path is:
+
+`gameplay/system code`
+→ `MessageRelay.RelayNative(...)` or `RelayModule(...)`
+→ serialize data with `NetWriter`
+→ create a `NetMessage`
+→ choose route/channel (`ToServer`, `ToClients`, `ToOtherClients`, `ToTarget`, etc.)
+→ `MessageSender`
+→ active `NetworkLayer` transport.
+
+If the host is also the logical recipient, `MessageSender` can feed the message back through local handling rather than requiring an actual loopback network packet.
+
+### Receiving/handling
+
+Incoming messages ultimately reach registered handlers. `MessageHandler` provides common validation/lifecycle behavior:
+
+- optional `NetAttribute` gates run before handling;
+- awaitable attributes can delay the final handler;
+- handlers declare expected server/client receiver type;
+- exceptions are caught and logged around the concrete `Handle(...)` implementation;
+- server-side handlers can reject a message before relay through `OnPreRelayMessage(...)`.
+
+The actual message payload types are grouped by purpose in `src/Network/Messages/` (server connection/state, entities, representation, scene levels, spawning, gamemodes, point shop, interaction, SDK RPCs, etc.).
+
+## Where a Counter-Strike-style economy would fit
+
+There are two existing systems that are easy to confuse:
+
+1. **Gamemode state** (`src/SDK/Gamemodes/`), which is already network-oriented and host-authoritative through gamemode metadata/messages.
+2. **Point-shop bits** (`src/SDK/Points/`), whose balance is persisted locally in `point_shop.dat` by `PointSaveManager`.
+
+For a competitive round economy, the second system should **not automatically be treated as the player's authoritative match money**. `PointSaveManager` persists a local cross-session bit balance and is designed around unlock/equip/upgrade state. A match economy such as `$800 start → round reward → weapon purchase → reset on new match` should instead be owned by the active gamemode/server and synchronized as match state.
+
+### Recommended first code path to inspect
+
+- `SDK/Gamemodes/Gamemode.cs`
+  - lifecycle callbacks: `OnGamemodeStarted`, `OnGamemodeStopped`, `OnLevelReady`, player join/leave and update phases;
+  - `Metadata` is already wired so the host can set/remove replicated gamemode values.
+- `SDK/Gamemodes/GamemodeManager.cs`
+  - selects/starts/stops the active gamemode and advances its update loop.
+- `SDK/Gamemodes/Teams/TeamManager.cs`
+  - maps players to teams through gamemode metadata and provides team assignment/query helpers.
+- existing built-in team/round gamemodes under `SDK/Gamemodes/Built In/`
+  - concrete examples for round lifecycle, player events and team-aware rules.
+- `Network/Messages/Gamemodes/` and `Senders/Gamemode/`
+  - existing synchronized gamemode control/metadata message patterns.
+
+### Suggested architecture for match money
+
+Keep authoritative balances on the host, keyed by `PlayerID.SmallID` (or another stable per-match player key), then expose only the minimum replicated state needed by clients. A basic sequence would be:
+
+1. initialize balances when the gamemode starts / a late player joins;
+2. server changes balances on validated events (round result, kill/objective reward, purchase);
+3. reject purchase requests when balance, phase or inventory rules fail;
+4. replicate the resulting balance/purchase outcome to clients;
+5. reset or carry balances according to explicit round/match rules;
+6. keep the persistent point-shop `BitCount` separate unless the feature deliberately wants cross-session progression.
+
+This uses Fusion's existing host-authority and message-routing model instead of making every client independently calculate its own economy state.
+
+## Next documentation slices
+
+If this map is useful, the next high-value pages would be:
+
+1. a directory-by-directory reference for `LabFusion/src/` and `BonelabSupport/`;
+2. a message-flow diagram from socket receive → native/module handler → gameplay state;
+3. a scene-load / join / catch-up sequence;
+4. a gamemode extension guide using one built-in gamemode as a worked example;
+5. a BONELAB-specific patch/extender map showing which functionality lives outside the generic Fusion layer.
+
+Those pages would turn this map into the fuller onboarding documentation requested in issue #107.

--- a/docs/CODEBASE_MAP.md
+++ b/docs/CODEBASE_MAP.md
@@ -4,28 +4,33 @@ Source inspected: `Lakatrazz/BONELAB-Fusion` at `4b0505be680b3232f3b2db862a3dcd2
 
 This is a focused developer map, not a complete API reference. It answers the questions from issue #107: where the main pieces live, how the runtime enters and updates them, how networking is layered, and where a gameplay/economy feature would plug in.
 
+Companion pages on this branch:
+
+- [`DIRECTORY_GUIDE.md`](DIRECTORY_GUIDE.md) - directory-by-directory orientation for `LabFusion/src/` and `BonelabSupport/`.
+- [`RUNTIME_AND_NETWORKING.md`](RUNTIME_AND_NETWORKING.md) - startup, frame order, scene/gamemode lifecycle and message flow.
+- [`CS_ECONOMY_EXTENSION_GUIDE.md`](CS_ECONOMY_EXTENSION_GUIDE.md) - concrete host-authoritative design for the Counter-Strike-style economy mentioned in issue #107.
+
 ## Top-level projects
 
-- `LabFusion/` — main Fusion mod. This contains the MelonLoader entrypoint, networking stack, player/entity replication, gamemode SDK, menus, point shop, voice, scene synchronization and most common multiplayer behavior.
-- `BonelabSupport/` — BONELAB-specific support module. It contains game-specific patches, messages and extenders for BONELAB controllers, arena/campaign behavior, props, player vitals and other BONELAB-only integration points.
-- `LabFusionUpdater/` — updater/plugin project used to keep Fusion releases current.
-- `Staging/` — release/staging material rather than the main runtime implementation.
-- `LabFusion.sln` — solution entrypoint for the C# projects.
+- `LabFusion/` - main Fusion mod. This contains the MelonLoader entrypoint, networking stack, player/entity replication, gamemode SDK, menus, point shop, voice, scene synchronization and most common multiplayer behavior.
+- `BonelabSupport/` - BONELAB-specific support module. It contains game-specific patches, messages and extenders for BONELAB controllers, arena/campaign behavior, props, player vitals and other BONELAB-only integration points.
+- `LabFusionUpdater/` - updater/plugin project used to keep Fusion releases current.
+- `LabFusion.sln` - solution entrypoint for the C# projects.
 
 Inside `LabFusion/`, the most useful source roots for feature work are:
 
-- `src/Network/` — transport abstraction, lobby/matchmaking interfaces, connection lifecycle, serialization and message routing.
-- `src/Entities/` — networked entities, players, props, ownership/registration and per-frame entity updates.
-- `src/Player/` — local/network player behavior and player IDs.
-- `src/Scene/` — scene/level lifecycle and network scene synchronization.
-- `src/SDK/Gamemodes/` — base gamemode API, built-in gamemodes, teams and gamemode metadata.
-- `src/SDK/Points/` — persistent local point/"bit" balance, purchasable point items and point-shop state.
-- `src/SDK/Messages/` and `src/Network/Messages/` — module/native message contracts and handlers.
-- `src/Senders/` — higher-level helpers that construct and relay common messages.
-- `src/RPC/` — RPC registration and network asset spawning/request helpers.
-- `src/Menu/` and `src/UI/` — Fusion menu data/pages, matchmaking UI and popup UI.
-- `src/Support/` — support-module loading/coordination.
-- `src/Utilities/Fusion/MultiplayerHooking.cs` — common multiplayer lifecycle hooks used by systems such as gamemodes.
+- `src/Network/` - transport abstraction, lobby/matchmaking interfaces, connection lifecycle, serialization and message routing.
+- `src/Entities/` - networked entities, players, props, ownership/registration and per-frame entity updates.
+- `src/Player/` - local/network player behavior and player IDs.
+- `src/Scene/` - scene/level lifecycle and network scene synchronization.
+- `src/SDK/Gamemodes/` - base gamemode API, built-in gamemodes, teams and gamemode metadata.
+- `src/SDK/Points/` - persistent local point/"bit" balance, purchasable point items and point-shop state.
+- `src/SDK/Messages/` and `src/Network/Messages/` - module/native message contracts and handlers.
+- `src/Senders/` - higher-level helpers that construct and relay common messages.
+- `src/RPC/` - RPC registration and network asset spawning/request helpers.
+- `src/Menu/` and `src/UI/` - Fusion menu data/pages, matchmaking UI and popup UI.
+- `src/Support/` - support-module loading/coordination.
+- `src/Utilities/Fusion/MultiplayerHooking.cs` - common multiplayer lifecycle hooks used by systems such as gamemodes.
 
 ## Runtime entrypoint and lifecycle
 

--- a/docs/CS_ECONOMY_EXTENSION_GUIDE.md
+++ b/docs/CS_ECONOMY_EXTENSION_GUIDE.md
@@ -1,0 +1,220 @@
+# Counter-Strike-style economy extension guide
+
+Issue #107 specifically mentions adding a Counter-Strike-style economy. Fusion already has most of the infrastructure needed, but the existing persistent point shop should not be used as the authoritative match wallet.
+
+## Existing systems to reuse
+
+### Gamemode lifecycle
+
+`LabFusion/src/SDK/Gamemodes/Gamemode.cs` and `GamemodeManager.cs` provide:
+
+- match selection/start/stop;
+- player join/leave callbacks while the mode is active;
+- per-frame/fixed/late update phases;
+- host-authoritative synchronized metadata;
+- trigger relay support;
+- ready-condition checks.
+
+### Teams and scores
+
+`TeamDeathmatch.cs` is the closest built-in example to read first.
+
+It demonstrates:
+
+- a `TeamManager` registered to the gamemode;
+- two teams stored through synchronized gamemode metadata;
+- host-only score mutation;
+- player-action events for kills;
+- late-join team assignment;
+- mode start/stop and level-ready setup;
+- mode-specific settings and local UI feedback.
+
+### Existing persistent points
+
+`PointSaveManager` stores `BitCount`, unlocked/equipped items and upgrades in `point_shop.dat`. `Deathmatch` and `TeamDeathmatch` award Bits after matches through `PointItemManager.RewardBits(...)`.
+
+That system is useful for **persistent progression**, but it has different semantics from CS match money:
+
+- it survives between sessions;
+- it is stored locally;
+- it is tied to point-shop unlock/equip/upgrade state;
+- built-in modes award it as a post-match reward.
+
+Do not make `$800 -> purchases -> round reward -> reset/carry` depend on that file unless persistent cross-session money is deliberately desired.
+
+## Recommended match state
+
+Keep the authoritative economy state on the host, owned by the active gamemode.
+
+A minimal model is:
+
+```text
+Dictionary<byte, int> balances              // PlayerID.SmallID -> match money
+Dictionary<byte, PurchaseState> purchases   // optional round purchase state
+RoundPhase phase                            // Buy, Live, RoundEnd, MatchEnd
+```
+
+The client should never send a final balance. It should only request an action such as `Buy("weapon-barcode")`.
+
+The host then validates:
+
+1. the sender is a connected player;
+2. the gamemode is active;
+3. the round is in a buy-allowed phase;
+4. the requested item exists in the server's catalog;
+5. the player meets team/loadout restrictions;
+6. the player has sufficient match balance;
+7. duplicate/limit rules allow the purchase.
+
+Only after validation should the host subtract money, grant/spawn the purchase and replicate the result.
+
+## Two synchronization options
+
+### Option A: gamemode metadata
+
+Use per-player keys, for example:
+
+```text
+economy.balance.<smallId> = "800"
+economy.phase = "Buy"
+```
+
+Advantages:
+
+- host-only `TrySetMetadata(...)` is already enforced by `Gamemode`;
+- reliable replication already exists through `GamemodeSender`;
+- clients automatically get change callbacks;
+- late join/catch-up can use the same gamemode state.
+
+This is the simplest choice for balances, phase and other small state.
+
+### Option B: custom purchase messages
+
+Use a custom client -> server message for purchase requests, then a server -> client result message.
+
+This is better when the request needs structured input or explicit rejection reasons. The existing network stack gives the pattern:
+
+```text
+client BuyRequest(itemId)
+  -> MessageRelay ... ToServer
+  -> server handler
+  -> validate against host state
+  -> mutate host balance/inventory
+  -> reliable BuyResult / metadata update
+  -> client UI reflects authoritative result
+```
+
+The server handler should use `ExpectedReceiverType.ServerOnly` and/or `OnPreRelayMessage(...)`/other validation hooks where appropriate.
+
+A practical design is to use **custom messages for commands** and **gamemode metadata for state**.
+
+## Suggested lifecycle
+
+### `OnGamemodeStarted()`
+
+Host:
+
+- clear any previous match economy state;
+- initialize all connected players with starting money;
+- initialize round phase;
+- initialize loss-streak/team-economy state if the design uses it.
+
+All clients:
+
+- initialize economy UI hooks/state listeners;
+- clear stale local presentation state.
+
+### `OnPlayerJoined(PlayerID)`
+
+Host:
+
+- assign the correct starting/late-join balance;
+- publish the new player's balance;
+- send/ensure current round phase and catalog rules are available.
+
+### Round start
+
+Host:
+
+- move phase to `Buy`;
+- apply per-round income/carry rules;
+- clear round-only purchase limits;
+- publish balances changed by round settlement.
+
+### Buy period
+
+Client:
+
+- request a purchase.
+
+Host:
+
+- validate the request;
+- deduct price;
+- grant the item through an appropriate server-authoritative path;
+- publish the new balance and purchase result.
+
+### Round end
+
+Host:
+
+- calculate winner/loser/objective rewards;
+- update loss streaks if used;
+- update each balance with explicit max-money clamping;
+- transition phase to round end/intermission.
+
+### `OnGamemodeStopped()`
+
+- remove economy-specific metadata or let the gamemode's nonpersistent metadata clear;
+- remove local UI hooks/overrides;
+- do **not** write the match balance into `PointSaveManager` unless the design explicitly converts some result into persistent Bits.
+
+## Concrete files to inspect/change
+
+For a new economy-based mode:
+
+1. `LabFusion/src/SDK/Gamemodes/Gamemode.cs`
+   - lifecycle and metadata rules.
+2. `LabFusion/src/SDK/Gamemodes/Built In/TeamDeathmatch.cs`
+   - strongest built-in example of teams + host-authoritative scoring + player actions.
+3. `LabFusion/src/SDK/Gamemodes/Teams/TeamManager.cs`
+   - synchronized team membership.
+4. `LabFusion/src/SDK/Gamemodes/Score/*.cs`
+   - metadata-backed synchronized score patterns.
+5. `LabFusion/src/SDK/Metadata/NetworkMetadata.cs`
+   - synchronized key/value state.
+6. `LabFusion/src/SDK/Metadata/MetadataVariable.cs`
+   - typed/serialized metadata convenience layer.
+7. `LabFusion/src/Senders/Gamemode/GamemodeSender.cs`
+   - existing gamemode metadata/trigger network sends.
+8. `LabFusion/src/Network/Messages/Gamemodes/`
+   - existing gamemode network handlers.
+9. `LabFusion/src/Network/Helpers/MessageRelay.cs`
+   - routing a new command/result message.
+10. `LabFusion/src/Network/Messages/MessageHandler.cs`
+    - server/client expectations and pre-relay validation.
+
+If actual BONELAB item spawning/granting needs BONELAB-only behavior, then follow the existing patterns in `BonelabSupport/` rather than putting game-specific patches into generic gamemode infrastructure.
+
+## What not to do
+
+- Do not let clients calculate and submit their own final balance.
+- Do not use `PointSaveManager.SetBitCount()` as the match wallet just because it already stores an integer currency.
+- Do not run economy mutation on every client in `OnUpdate()` and hope values stay in sync.
+- Do not put a BONELAB-only spawn patch into generic `LabFusion` if it belongs in `BonelabSupport`.
+- Do not send balance state every render frame; update it on economy events.
+
+## Minimal implementation sequence
+
+A low-risk first implementation can be built in this order:
+
+1. new gamemode with host-owned `balances` dictionary;
+2. balance replication through gamemode metadata;
+3. start money + late-join initialization;
+4. one hard-coded buyable item and a validated purchase request;
+5. round-end reward and max-money clamping;
+6. client display of authoritative balance;
+7. catalog/settings extraction;
+8. team-specific pricing/loadout rules if needed.
+
+That produces a testable vertical slice before adding a full CS-like shop.

--- a/docs/DIRECTORY_GUIDE.md
+++ b/docs/DIRECTORY_GUIDE.md
@@ -1,0 +1,123 @@
+# Directory guide
+
+This guide is for developers entering Fusion without already knowing the codebase. It is based on `Lakatrazz/BONELAB-Fusion` commit `4b0505be680b3232f3b2db862a3dcd21bba43de7`.
+
+The rule of thumb is:
+
+- `LabFusion/` owns reusable multiplayer infrastructure and Fusion gameplay systems.
+- `BonelabSupport/` owns BONELAB-specific hooks and behavior that cannot live in the generic Fusion layer.
+- `LabFusionUpdater/` is the updater/plugin.
+
+## `LabFusion/src/`
+
+| Directory | What lives here | Start with |
+| --- | --- | --- |
+| `Audio/` | Shared audio helpers and references used by Fusion systems. | Follow references from a gamemode or UI feature rather than starting here. |
+| `Data/` | Persistent/config data models, file containers, lobby/mod metadata and serialization-oriented data structures. | `PersistentData`, `DataSaver`, then the `Containers/`, `Files/`, `Lobbies/`, `Mods/` and `Serializables/` subfolders. |
+| `Debugging/` | Debug-only diagnostics and development helpers. | Useful when adding diagnostics, not a normal feature entrypoint. |
+| `Downloading/` | Mod/download coordination. `ModIO/` contains Mod.io-specific download logic. | `ModDownloadManager`, then `ModIO/` for Mod.io flows. |
+| `Entities/` | Network entity registration, replicated entities, player entities, props, ownership/validation and component extenders. | `NetworkEntityManager`, then `Player/`, `Props/`, `Components/` and `Extenders/`. |
+| `Exceptions/` | Fusion-specific exception types. | Search for the exception from the call site that throws it. |
+| `Extensions/` | General C# extension methods. | Treat as utility code; avoid placing feature state here. |
+| `Grabbables/` | Grab-group registration and synchronization. | `GrabGroupHandler` and concrete handlers. |
+| `Marrow/` | Integration helpers around SLZ Marrow: asset warehouse, audio, circuits, combat, pooling, scenes, zones, serialization and patches. | Use when a feature needs BONELAB/Marrow object behavior but is still generic enough for Fusion. |
+| `Math/` | Math helpers used by gameplay/network code. | Utility-only. |
+| `Menu/` | Fusion menu model, pages, matchmaking/gamemode settings and popup data. | `MenuCreator`, then `Pages/`, `Matchmaking/` or `Gamemodes/`. |
+| `MonoBehaviours/` | Fusion-owned Unity behaviours. | Search by component name from the feature using it. |
+| `Network/` | Transport abstraction, connection/lobby state, native messages, serialization and routing. | `NetworkLayer`, `NetworkLayerManager`, `MessageRelay`, `MessageSender`, `NativeMessageHandler`. |
+| `Patching/` | Harmony/IL2CPP patches and patch helpers for generic Fusion behavior. | `Patches/` for concrete hooks. |
+| `Permissions/` | Server/client permission model. | Check this before exposing a host-only action to clients. |
+| `Player/` | Player identity plus local/network player state. | `PlayerID`, `PlayerIDManager`, `Local/`, `Network/`. |
+| `Preferences/` | User/server settings and preference registration. | `FusionPreferences`, then `Client/` and `Server/`. |
+| `Representation/` | Networked player/avatar representation logic. | Relevant when changing how remote players are represented. |
+| `RPC/` | RPC discovery/registration and network asset/spawn request helpers. | `RpcManager` and existing RPCs as examples. |
+| `Safety/` | Safety filters, lists, patches and trackers. | Treat as policy/validation infrastructure rather than gameplay state. |
+| `Scene/` | Fusion level lifecycle and network scene synchronization. | `FusionSceneManager`, `NetworkSceneManager`, `Scene/Network/`. |
+| `SDK/` | Public-ish extension surface: gamemodes, metadata, modules, points, messages, scenes, triggers, cosmetics, achievements and lobbies. | For a new game mode or feature, this is usually the first place to inspect. |
+| `Senders/` | Higher-level helpers that construct and relay common network messages. | `Gamemode/`, `Player/`, `Props/`, `Server/`. |
+| `Support/` | Support-module discovery/coordination. | `SupportManager`; this is how game-specific support is loaded. |
+| `UI/` | Fusion runtime UI helpers/components. | `Popups/`, `Cup Board/`, `Info Box/`. |
+| `Utilities/` | General/internal/Fusion-specific utility code and lifecycle hooks. | `Utilities/Fusion/MultiplayerHooking.cs` is especially important. |
+| `Voice/` | Voice transport/playback integration. | `VoiceHelper`, voice managers and `Voice/Unity/`. |
+
+## `LabFusion/src/Network/`
+
+Networking is split so gameplay code does not need to know whether the transport is Steam or Proxy.
+
+- `Layers/` defines and selects transports.
+  - `NetworkLayer.cs` is the abstract transport contract.
+  - `NetworkLayerManager.cs` owns the active layer.
+  - `NetworkLayerDeterminer.cs` chooses a target layer.
+  - transport implementations live below `Layers/Steam/` and `Layers/Proxy/`.
+- `Helpers/` is the normal gameplay-facing network API.
+  - `MessageRelay.cs` serializes typed data and chooses a route.
+  - `MessageSender.cs` bridges routing decisions into the active `NetworkLayer`.
+  - `NetworkInfo.cs` exposes host/server/connection state.
+  - `MetadataHelper.cs` and other helpers support common synchronized-state patterns.
+- `Messages/` contains the message framework plus native message groups.
+  - `NetMessage`, `ReceivedMessage`, `ReadableMessage` are the envelope/receive structures.
+  - `MessageHandler` is the common handler base.
+  - `NativeMessageHandler` discovers and dispatches native handlers.
+  - feature-specific messages live in subdirectories such as `Gamemodes/`.
+- `Serialization/` contains `NetReader`, `NetWriter` and serializable contracts.
+- `Lobbies/` contains lobby/matchmaker contracts and lobby metadata.
+- `Data/` contains compact payload structures shared by network code.
+- `Internal/` contains lower-level layer/server helpers used by the runtime loop.
+- `Fallback/` contains the empty/fallback layer.
+
+## `LabFusion/src/SDK/Gamemodes/`
+
+This is the best reference for a Counter-Strike-style mode.
+
+- `Gamemode.cs` is the base lifecycle and synchronized metadata owner.
+- `GamemodeManager.cs` selects, readies, starts, stops and updates the active mode.
+- `GamemodeRegistration.cs` discovers/registers gamemode implementations.
+- `GamemodeConditionsChecker.cs` drives ready-condition checks.
+- `GamemodeRoundManager.cs` handles configured level rotations and inter-round progression.
+- `Teams/` provides `Team`, `TeamManager`, team logos and team music.
+- `Score/` provides player/team score keepers backed by gamemode metadata.
+- `Levels/` contains level rotation data.
+- `Music/` contains gamemode music helpers.
+- `Built In/` contains complete working examples: `Deathmatch`, `TeamDeathmatch`, `HideAndSeek`, `Juggernaut`, `SmashBones`, `Entangled`.
+
+For an economy-heavy team mode, read `TeamDeathmatch.cs` first. It demonstrates team registration, host-only score mutation, late-join team assignment, per-frame host checks, settings, round start/stop behavior and client-facing feedback.
+
+## `LabFusion/src/SDK/Points/`
+
+This is a **persistent progression/shop system**, not a ready-made authoritative match-currency system.
+
+- `PointSaveManager.cs` stores bought/equipped/upgraded items and `BitCount` in `point_shop.dat`.
+- `PointItemManager.cs` discovers point items and handles rewards/purchases/equipment.
+- `PointItem.cs` is the item abstraction.
+- `PointShopHelper.cs` supports shop behavior.
+- `BitEconomy.cs` currently only defines a high sentinel price (`PricelessValue`).
+- `Built In/Passive/BitMiner.cs` is an example built-in point item.
+
+A match economy should not directly reuse `PointSaveManager.BitCount` unless cross-session currency is intentionally part of the design.
+
+## `BonelabSupport/`
+
+`BonelabSupport` is where Fusion adapts generic multiplayer infrastructure to BONELAB-specific game objects and systems.
+
+| Directory | Purpose |
+| --- | --- |
+| `AssetWarehouse/` | BONELAB-specific asset references and backlot/spawnable/avatar/disc lookups. |
+| `Extenders/` | Entity/component/player extenders for BONELAB objects. |
+| `Messages/` | BONELAB-specific network messages grouped by arena, campaign, interaction, level, player and props. |
+| `Patching/` | BONELAB-specific patches grouped by arena, campaign, interaction, level, props, spawning, triggers and UI. |
+| `SDK/` | BONELAB-facing SDK additions such as BitMart/music integration and achievements. |
+| `Scene/` | BONELAB scene event integration, including arena/campaign/general/parkour/sandbox/tac-trial event groups. |
+| `Serialization/` | BONELAB-specific serialized data such as body vitals. |
+
+`BonelabSupport/BonelabModule.cs` is the module-level entrypoint to read before changing this project.
+
+## Where to place a new feature
+
+Use the narrowest layer that owns the concept:
+
+- Generic synchronized game rules: `LabFusion/src/SDK/Gamemodes/`.
+- Generic message contract: `LabFusion/src/Network/Messages/` plus a sender helper when useful.
+- Generic local UI: `LabFusion/src/Menu/` or `LabFusion/src/UI/`.
+- BONELAB-only patch/object behavior: `BonelabSupport/`.
+- Cross-session unlock/shop progression: `LabFusion/src/SDK/Points/`.
+- One match's authoritative score/money/round phase: active gamemode state, not the persistent point save.

--- a/docs/RUNTIME_AND_NETWORKING.md
+++ b/docs/RUNTIME_AND_NETWORKING.md
@@ -1,0 +1,206 @@
+# Runtime and networking flow
+
+This page traces Fusion from MelonLoader startup through frame updates and message delivery. Paths refer to `Lakatrazz/BONELAB-Fusion` commit `4b0505be680b3232f3b2db862a3dcd21bba43de7`.
+
+## 1. Startup
+
+The main entrypoint is `LabFusion/src/Mod.cs`, `FusionMod : MelonMod`.
+
+### `OnEarlyInitializeMelon()`
+
+The early phase establishes data and APIs before most feature discovery:
+
+1. cache the mod/assembly references;
+2. remove temporary mod-download directories;
+3. initialize the persistent-data path;
+4. load Steam API support;
+5. initialize player-data control;
+6. hook point-item events;
+7. initialize the RPC manager.
+
+### `OnInitializeMelon()`
+
+The main phase wires the runtime:
+
+1. load Fusion files and safety lists;
+2. initialize local-player and voice state;
+3. load base/support modules;
+4. scan the Fusion assembly for native message handlers, grab handlers, network layers, gamemodes, point items, achievements and RPCs;
+5. discover entity components;
+6. initialize network entity/player managers;
+7. initialize popups and gamemode managers;
+8. initialize preferences, permissions, lobby state and menus;
+9. initialize scene loading and the network scene manager;
+10. initialize the network layer manager.
+
+The repeated `Register...FromAssembly` / `Load...` pattern matters: extension points are often discovered by type rather than manually added to `Mod.cs`.
+
+## 2. Scene lifecycle
+
+`FusionMod` registers scene-related hooks after core initialization.
+
+When the main scene becomes ready, `OnMainSceneInitialized()`:
+
+- cleans network-entity IDs;
+- caches rig information;
+- initializes persistent assets and constrainer helpers;
+- invokes `MultiplayerHooking.OnMainSceneInitialized`;
+- lets `FusionPlayer` perform its scene initialization.
+
+A delayed scene initialization then makes sure the rig exists and creates the Fusion menu.
+
+`GamemodeManager` listens to scene hooks too:
+
+- when a main scene initializes, the host stops an active gamemode if `AutoStopOnSceneLoad` is true;
+- when the server target level is loaded, an already-running gamemode receives `OnLevelReady()`.
+
+This distinction is useful for game modes: `OnGamemodeStarted()` owns match-state start, while `OnLevelReady()` is where level-local objects/spawns/settings should be applied.
+
+## 3. Per-frame order
+
+`FusionMod.OnUpdate()` gives the clearest top-level order:
+
+```text
+reset byte counters
+  -> mod download queue
+  -> time references
+  -> scene-load state
+  -> popup UI
+  -> network tick calculation
+  -> network players
+  -> network entities
+  -> local Fusion player
+  -> voice
+  -> active transport OnUpdateLayer
+  -> delayed disconnects
+  -> shared multiplayer OnUpdate hooks
+  -> active gamemode Update
+  -> delayed events
+```
+
+`OnFixedUpdate()` handles physics-oriented work:
+
+```text
+time fixed update
+  -> local player
+  -> player-data controller
+  -> network players
+  -> network entities
+  -> multiplayer fixed hooks
+  -> active gamemode FixedUpdate
+```
+
+`OnLateUpdate()` handles late player/entity work, flushes transport work, runs late multiplayer hooks, then invokes the active gamemode's late update.
+
+## 4. Network tick
+
+`LabFusion/src/Network/NetworkTickManager.cs` defines a 20 Hz tick (`0.05s` between ticks). Systems can use `IsTickThisFrame` to avoid sending state every render frame. The same manager exposes an interpolation decay value for smoothing between ticks.
+
+This is the cadence to consider for replicated state that needs regular updates. Event-style state such as a purchase result or round reward should normally be sent only when it changes.
+
+## 5. Transport abstraction
+
+`LabFusion/src/Network/Layers/NetworkLayer.cs` is the transport contract. It provides:
+
+- host/client state;
+- platform identity;
+- lobby and matchmaker objects;
+- voice manager;
+- start/disconnect operations;
+- send-to-server, send-from-server and broadcast operations;
+- per-frame and late-frame layer updates.
+
+`NetworkLayerManager` owns the active layer. Gameplay code should normally use `NetworkInfo`, `MessageRelay`, `MessageSender` and registered message handlers rather than talking directly to Steam/Proxy transport implementation classes.
+
+## 6. Native message send path
+
+For a typed payload implementing `INetSerializable`, the common path is:
+
+```text
+feature code
+  -> MessageRelay.RelayNative(data, tag, route)
+  -> NetWriter
+  -> NetMessage.Create(...)
+  -> route switch
+  -> MessageSender
+  -> active NetworkLayer
+```
+
+`MessageRoute` controls where the message goes:
+
+- `None` / `ToServer` -> server;
+- `ToClients` -> host broadcasts, client sends to server;
+- `ToOtherClients` -> host broadcasts except sender, client sends to server;
+- `ToTarget` / `ToTargets` -> host can target specific clients; a client sends the request through the server.
+
+`MessageSender` also handles host loopback. If the host logically receives a server-targeted message, it can feed the message directly through `NativeMessageHandler.ReadMessage(...)` instead of requiring a real network round trip.
+
+## 7. Receive/handler path
+
+Incoming native messages are dispatched through the registered message-handler system.
+
+`MessageHandler` provides the common pipeline:
+
+1. initialize `NetAttribute` guards;
+2. stop early if a guard rejects handling;
+3. wait for an awaitable guard if needed;
+4. verify expected server/client conditions;
+5. call the concrete `Handle(...)` implementation;
+6. catch/log exceptions around handler execution.
+
+On server relay paths, a handler can reject a message before it is forwarded by overriding `OnPreRelayMessage(...)`.
+
+That is the correct layer for validating a client-originating purchase request: do not trust a client-provided final balance or price.
+
+## 8. Gamemode synchronized metadata
+
+Each `Gamemode` owns a `NetworkMetadata` instance.
+
+A normal `TrySetMetadata(key, value)` from the gamemode delegates into `Gamemode.OnTrySetMetadata(...)`, which refuses non-host callers and then sends a `GamemodeMetadataSet` message through `GamemodeSender`.
+
+So the flow is:
+
+```text
+host gamemode code
+  -> Metadata.TrySetMetadata(key, value)
+  -> Gamemode.OnTrySetMetadata
+  -> GamemodeSender.SendGamemodeMetadataSet
+  -> reliable message to clients
+  -> client metadata updated
+  -> OnMetadataChanged callbacks fire
+```
+
+`TeamManager` and the score keepers already use this pattern. It is appropriate for relatively small replicated state such as team membership, score, mode settings and player balances.
+
+## 9. Gamemode lifecycle
+
+`GamemodeManager` owns the active gamemode.
+
+Host-only state transitions are reflected through gamemode metadata:
+
+- `SelectGamemode()` -> selected metadata key;
+- `ReadyGamemode()` / `UnreadyGamemode()` -> ready key;
+- `StartGamemode()` / `StopGamemode()` -> started key.
+
+When those metadata values change locally, callbacks invoke the corresponding gamemode lifecycle methods. A started mode then receives `Update`, `FixedUpdate` and `LateUpdate` from the main Fusion loop.
+
+A new gameplay mode should therefore put match rules inside the gamemode lifecycle rather than adding another global update system.
+
+## 10. Join and late-join implications
+
+`Gamemode.GamemodeRegistered()` subscribes the mode to `MultiplayerHooking.OnPlayerJoined` and `OnPlayerLeft`. The protected `OnPlayerJoined(PlayerID)` and `OnPlayerLeft(PlayerID)` callbacks are only invoked while that gamemode is started.
+
+For a match economy this is where the host should initialize/remove per-player match state. `TeamDeathmatch` also demonstrates a useful late-join pattern: if the host receives a player join while the match is active, it assigns that player to the smallest team.
+
+## Practical debugging path
+
+When a synchronized feature does not behave as expected, check in this order:
+
+1. Is the active gamemode actually selected/started?
+2. Is the mutation running only on the host when it should be authoritative?
+3. Is the metadata/message request being created?
+4. Is the route correct for server/client direction?
+5. Is the active `NetworkLayer` present and connected?
+6. Does the handler expect server, clients or both?
+7. Is an attribute guard stopping/delaying handling?
+8. Does the recipient update local metadata/state and fire the expected callback?


### PR DESCRIPTION
Addresses the documentation scope in #107.

Adds four focused guides:
- `docs/CODEBASE_MAP.md` — entry points and major subsystems
- `docs/DIRECTORY_GUIDE.md` — directory ownership/orientation
- `docs/RUNTIME_AND_NETWORKING.md` — startup, scene/frame flow, 20 Hz network tick, transport/message paths, late joins
- `docs/CS_ECONOMY_EXTENSION_GUIDE.md` — a concrete host-authoritative Counter-Strike-style match economy design that keeps match money separate from locally persisted point-shop bits

Validation:
- relative Markdown links checked: 3/3 valid
- repository path assumptions reviewed against the current checkout
- `git diff --check`: clean

This is documentation only; it does not change runtime behavior.